### PR TITLE
add pdf links for faskowitz posters

### DIFF
--- a/posters-overrides.json
+++ b/posters-overrides.json
@@ -2880,7 +2880,8 @@
    "number": 1030
   },
   {
-   "number": 1031
+   "number": 1031,
+   "pdf": "https://github.com/faskowit/faskowit.github.io/blob/master/host/faskowitz1_ohbm2020_pdfcopy.pdf" 
   },
   {
    "number": 1032
@@ -3322,7 +3323,8 @@
    "number": 1181
   },
   {
-   "number": 1182
+   "number": 1182,
+   "pdf": "https://github.com/faskowit/faskowit.github.io/blob/master/host/faskowitz2_ohbm2020_pdfcopy.pdf"
   },
   {
    "number": 1183
@@ -4725,7 +4727,8 @@
    "number": 1673
   },
   {
-   "number": 1674
+   "number": 1674,
+   "pdf": "https://github.com/faskowit/faskowit.github.io/blob/master/host/faskowitz3_ohbm2020_pdfcopy.pdf"
   },
   {
    "number": 1675


### PR DESCRIPTION
cheers

<!--

Thanks for updating your poster entry! Here are some guidelines to ensure your PR can be
merged quickly.

Your PR should only touch the lines in the entry in posters-overrides.json describing your
own poster. For example, if your poster is #1895, then your diff might look like

----

diff --git a/posters-overrides.json b/posters-overrides.json
index 705a583..41f47dd 100644
--- a/posters-overrides.json
+++ b/posters-overrides.json
@@ -5364,7 +5364,9 @@
    "number": 1894
   },
   {
-   "number": 1895
+   "number": 1895,
+   "videochat": "<a href=\"https://meet.jit.si/bids-derivatives\" target=\"_bids-derivatives\">jitsi:bids-derivatives</a>",
+   "pdf": "https://cdn-akamai.6connex.com/645/1827/poster_15922429379118925.pdf"
   },
   {
    "number": 1896

----

Any field besides "number" can be overridden from posters.json, including:

* `"title"`: String
* `"institution"`: String
* `"presenter"`: String
* `"categories"`: String
* `"videochat"`: String (use literal `<a href="..."></a>` to
* `"pdf"`:  URL

Note that you must use standard double-quotes for values. Consider passing your JSON through
a validator (https://duckduckgo.com/?q=json+validator) before submitting.

-->
