### PR TITLE
Adds abstract info JSON

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -473,6 +473,8 @@ function directory(jQuery) {
       {data: "categories", title: "Categories", className: "dt-left", width: "10%"},
       {data: "videochat", title: "Video Chat", className: "dt-left", width: "18%"},
       {data: "pdf", title: "PDF", className: "dt-left", width: "8%"},
+      {data: "authors", visible: false},
+      {data: "keywords", visible: false},
     ],
     createdRow: function(row, data, index) {
         if (data.pdf === '') {

--- a/tools/make_page.py
+++ b/tools/make_page.py
@@ -38,12 +38,16 @@ thisfile = Path(__file__)
 infile = thisfile.parent.parent / 'OHBM 2020 Poster Numbering - AbstractsAdHocReport_2015_20200.tsv'
 sdfile = thisfile.parent.parent / 'SoftwareDemos.tsv'
 dlfile = thisfile.parent.parent / 'poster_downloads_matches.csv'
+abfile = thisfile.parent.parent / 'abstract.json'
 
 urls = dict()
 for line in csv.DictReader(dlfile.read_text().splitlines(), quotechar='"', delimiter=','):
     if line['number'] in [None, ''] or '.comet:' in line['url']:
         continue
     urls[int(line['number'])] = line['url']
+
+with abfile.open('r') as src:
+    abstracts = {a['number']: a for a in json.load(src)}
 
 recs = []
 overrides = []
@@ -68,6 +72,8 @@ for line in chain(
         url = 'ohbm2020-{number}'.format(**rec)
         rec['videochat'] = f'<a href="https://meet.jit.si/{url}" target="_{url}">jitsi:{url}</a>'
         rec['pdf'] = rec.get('pdf', urls.get(rec['number'], ''))
+        rec['authors'] = abstracts.get(rec['number'], {}).get('authors', [])
+        rec['keywords'] = abstracts.get(rec['number'], {}).get('keyword', [])
         recs.append(rec)
         overrides.append({'number': rec['number']})
     except ValueError:

--- a/tools/scrape_abstracts.py
+++ b/tools/scrape_abstracts.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+from collections import Counter
+import json
+import re
+from string import punctuation as PUNCTUATION
+
+from bs4 import BeautifulSoup
+import requests
+
+
+def check_figure_caption_end(node):
+    bad_class = ['abstractcaption', 'priorityOrderHint', 'clear']
+    return (node.next.name != 'a'
+            and node.attrs.get('class', [''])[0] not in bad_class)
+
+
+def loop_until_end(text, start, end, sep=''):
+    # we passed the "end" h4 marker; abort abort
+    if start is None or start.find_next('h4') != end:
+        return text.strip(sep)
+    # don't include figures or figure captions; we just want text
+    if check_figure_caption_end(start):
+        text += start.text.strip() + sep
+    # recurse, baby
+    return loop_until_end(text, start.find_next('div'), end, sep=sep)
+
+
+# get list of all abstract IDs (these are NOT poster IDs; they're for internal
+# use in the OHBM abstract system)
+# we'll save a list of the actual poster IDs and the relevant URL that links to
+# the abstract
+abstract_no = re.compile(r'\((\d+)\)')
+url = "https://ww4.aievolution.com/hbm2001/index.cfm?do=abs.pubSearchAbstracts"
+abslist = requests.get(url)
+abslist.raise_for_status()
+content = BeautifulSoup(abslist.content, 'lxml')
+abstracts = []
+url = "https://ww4.aievolution.com/hbm2001/index.cfm?do=abs.viewAbs&abs={}"
+for abno in content.find_all('td', attrs={'class': 'abstractnumber'}):
+    href = abno.find_next('a')
+    match = abstract_no.search(href.get('href', ''))
+    if match:
+        abstracts.append({
+            'number': int(abno.text),
+            'url': url.format(match.group(1))
+        })
+
+# go through each poster, fetch the abstract, and parse it. store some
+# relevant info and discard the rest
+relevant = ['Introduction:', 'Methods:', 'Results:', 'Conclusions:']
+bag_of_words = Counter()
+for n, abstr in enumerate(abstracts):
+    if n % 10 == 0:
+        print(n)
+    # let's not re-run this for things we've already run (if you're messing
+    # around interactively)
+    if abstr.get('abstract') is not None:
+        continue
+
+    # get the abstract webpage
+    resp = requests.get(abstr['url'])
+    resp.raise_for_status()
+    page = BeautifulSoup(resp.content, 'lxml')
+
+    # get the abstract body and other relevant info
+    body = set()
+    for h4 in page.find_all('h4'):
+        # if we found part of the abstract (intro/methods/results/conclusions)
+        if any(r == h4.text.strip() for r in relevant):
+            # grab the body of this section
+            text = loop_until_end('', h4.find_next('div'), h4.find_next('h4'))
+            # strip punctuation and don't include numbers and add to word bag
+            body.update([
+                f.strip(PUNCTUATION).lower() for f in text.split(' ')
+                if re.sub(r'\d+', '', f).strip(PUNCTUATION).lower() != ''
+            ])
+        # if we found the authors, make a nice list of their names and
+        # get rid of the pesky affiliation numbering
+        elif h4.text.strip() == 'Authors:':
+            authors = h4.find_next('div').text.strip()
+            authors = re.sub(r',+(\s)*', ',', re.sub(r'\d', '', authors))
+            authors = authors.split(',')[:-1]
+            abstr['authors'] = authors
+        # if we found keywords, make a nice list of them
+        # we're lowercasing them because random ones are uppercased but we
+        # can make them real ("mri" --> "MRI") later if we want for a select
+        # group of keywords
+        elif h4.text.strip() == 'Keywords:':
+            kws = loop_until_end('', h4.find_next('div'), h4.find_next('h4'),
+                                 sep=',')
+            abstr['keywords'] = [f.lower() for f in kws.split(',')]
+    # save abstract body and add this to our global bag of words
+    abstr['abstract'] = body
+    bag_of_words.update(body)
+
+# drop words occurring in more than 25% of abstracts; we want unique words!
+too_common = {k for k, v in bag_of_words.items() if v > 0.25 * len(abstracts)}
+for abstr in abstracts:
+    abstr['abstract'] = list(abstr['abstract'].difference(too_common))
+
+# dump to json
+with open('abstract.json', 'w') as dest:
+    json.dump(abstracts, dest, indent=1, ensure_ascii=True)


### PR DESCRIPTION
Related to #31, #38, and #44.

I know the JSON is a _bit_ big (tried to minify it to reduce size 🤷‍♂️), but it has (1) all the authors for each poster, (2) the URL to the abstract from AIEvolution (though that's hopefully not necessary anymore), (3) keywords for each poster (a la @nicholst), and (4) a bag of words for each abstract, filtered for words that occur in more than 25% of all abstract.

@yarikoptic @effigies thoughts on adding any or part of this to the search somehow? Don't want to explode the poster.json file but I can edit make_pages.py to integrate stuff as desired!