### PR TITLE
[1424] update Presenter and Poster URL

### DIFF
--- a/posters-overrides.json
+++ b/posters-overrides.json
@@ -4019,7 +4019,9 @@
    "number": 1423
   },
   {
-   "number": 1424
+   "number": 1424,
+   "presenter": "Jorge Bosch-Bayard and Christine Rogers",
+   "pdf": "https://cdn-akamai.6connex.com//645/1827//OHBM_Qeegt-Cbrain_Poster_2020_15922367208559419.pdf"
   },
   {
    "number": 1425


### PR DESCRIPTION
Bosch-Bayard, Montreal Neurological Institute, HBM 2020 poster and Software Demo:  qEEG CBRAIN
category:  EEG/MEG Modelling and Analysis
