### PR TITLE
add videochat and pdf to poster 1759

### DIFF
--- a/posters-overrides.json
+++ b/posters-overrides.json
@@ -5003,7 +5003,30 @@
    "number": 1758
   },
   {
-   "number": 1759
+   "number": 1759,
+   "title": "ME-fMRI connectivity associations with behavior using group and individualized parcellation schemes",
+   "institution": "McGill University",
+   "presenter": "Roni Setton",
+   "categories": "Modeling and Analysis Methods<br>fMRI Connectivity and Network Modeling",
+   "videochat": "<a href=\"https://meet.jit.si/ohbm2020-1759\" target=\"_ohbm2020-1759\">jitsi:ohbm2020-1759</a>",
+   "pdf": "https://github.com/rsetton/misc/blob/master/OHBM_L%26R.pdf",
+   "authors": [
+    "Roni Setton",
+    "Laetitia Mwilambwe Tshilobo",
+    "Giulia Baracchini",
+    "Manesh Girn",
+    "Amber Lockrow",
+    "Jian Li",
+    "Tian Ge",
+    "Richard Leahy",
+    "Gary Turner",
+    "Nathan Spreng"
+   ],
+   "keywords": [
+    "cognition",
+    "functional mri"
+   ],
+   "software-demo": ""
   },
   {
    "number": 1760

--- a/posters-overrides.json
+++ b/posters-overrides.json
@@ -5004,29 +5004,7 @@
   },
   {
    "number": 1759,
-   "title": "ME-fMRI connectivity associations with behavior using group and individualized parcellation schemes",
-   "institution": "McGill University",
-   "presenter": "Roni Setton",
-   "categories": "Modeling and Analysis Methods<br>fMRI Connectivity and Network Modeling",
-   "videochat": "<a href=\"https://meet.jit.si/ohbm2020-1759\" target=\"_ohbm2020-1759\">jitsi:ohbm2020-1759</a>",
-   "pdf": "https://github.com/rsetton/misc/blob/master/OHBM_L%26R.pdf",
-   "authors": [
-    "Roni Setton",
-    "Laetitia Mwilambwe Tshilobo",
-    "Giulia Baracchini",
-    "Manesh Girn",
-    "Amber Lockrow",
-    "Jian Li",
-    "Tian Ge",
-    "Richard Leahy",
-    "Gary Turner",
-    "Nathan Spreng"
-   ],
-   "keywords": [
-    "cognition",
-    "functional mri"
-   ],
-   "software-demo": ""
+   "pdf": "https://github.com/rsetton/misc/raw/master/OHBM_L%26R.pdf"
   },
   {
    "number": 1760


### PR DESCRIPTION
<!--

Thanks for updating your poster entry! Here are some guidelines to ensure your PR can be
merged quickly.

Your PR should only touch the lines in the entry in posters-overrides.json describing your
own poster. For example, if your poster is #1895, then your diff might look like

----

diff --git a/posters-overrides.json b/posters-overrides.json
index 705a583..41f47dd 100644
--- a/posters-overrides.json
+++ b/posters-overrides.json
@@ -5364,7 +5364,9 @@
    "number": 1894
   },
   {
-   "number": 1895
+   "number": 1895,
+   "videochat": "<a href=\"https://meet.jit.si/bids-derivatives\" target=\"_bids-derivatives\">jitsi:bids-derivatives</a>",
+   "pdf": "https://cdn-akamai.6connex.com/645/1827/poster_15922429379118925.pdf"
   },
   {
    "number": 1896

----

Any field besides "number" can be overridden from posters.json, including:

* `"title"`: String
* `"institution"`: String
* `"presenter"`: String
* `"categories"`: String
* `"videochat"`: String (use literal `<a href="..."></a>` to
* `"pdf"`:  URL

Note that you must use standard double-quotes for values. Consider passing your JSON through
a validator (https://duckduckgo.com/?q=json+validator) before submitting.

-->
